### PR TITLE
Fixes for pip-installed CLI invocation

### DIFF
--- a/scdefg/__init__.py
+++ b/scdefg/__init__.py
@@ -1,1 +1,1 @@
-from scdefg.app import app
+

--- a/scdefg/app.py
+++ b/scdefg/app.py
@@ -341,12 +341,12 @@ if __name__ == '__main__':
     print('Starting launch function...')
     launch()
 
-else:
-    # this code is run if the file is imported as a module
-    #
-    # os.environ reads env variables from the system
-    # APP_SELECTION_COLUMNS is passed as a single variable, so it needs to be split
-    app = run(scvi_tools_model_path=os.environ["SCVI_TOOLS_MODEL_PATH"],
-              selection_columns=os.environ["APP_SELECTION_COLUMNS"].split(","),
-              intro_text_html=os.environ["APP_INTRO_TEXT_HTML"], host=os.environ["APP_HOST"], port=os.environ["APP_PORT"],
-              run_app=False)
+# else:
+#     # this code is run if the file is imported as a module
+#     #
+#     # os.environ reads env variables from the system
+#     # APP_SELECTION_COLUMNS is passed as a single variable, so it needs to be split
+#     app = run(scvi_tools_model_path=os.environ["SCVI_TOOLS_MODEL_PATH"],
+#               selection_columns=os.environ["APP_SELECTION_COLUMNS"].split(","),
+#               intro_text_html=os.environ["APP_INTRO_TEXT_HTML"], host=os.environ["APP_HOST"], port=os.environ["APP_PORT"],
+#               run_app=False)

--- a/setup.py
+++ b/setup.py
@@ -27,5 +27,6 @@ with open("README.md", "r", encoding="utf-8") as fh:
             "Topic :: Scientific/Engineering :: Bio-Informatics",
         ],
         python_requires='>=3.6',
+        entry_points={"console_scripts": ["scdefg-launch = scdefg.app:launch"]}
     )
 


### PR DESCRIPTION
Some updates and fixes that should allow the pip-installed app to be invoked via `scdefg-launch` command (rename as desired in `setup.py`).

Localhost web server initializes but requests are generate a 500 error, but I didn't dive into debugging that:
```
jinja2.exceptions.TemplateNotFound: home.html
INFO:werkzeug:127.0.0.1 - - [13/Sep/2021 12:09:26] "GET / HTTP/1.1" 500 -
```